### PR TITLE
chore: include test directory for linting

### DIFF
--- a/static/.codeclimate.yml
+++ b/static/.codeclimate.yml
@@ -14,4 +14,3 @@ ratings:
 exclude_paths:
 - db/**/*
 - node_modules/**/*
-- test/**/*


### PR DESCRIPTION
@masone : just to be sure I'm getting this right. When this PR is gonna be merged, all Livingdocs projects will fail on codeclimate because of linting errors ?
That means: server, editor, framework, beta... also on downstream with the editor and the api ?

Is it not better for me to test locally this change, fix the linting in all repos and then merge this PR. this way no one will be annoyed ?
