### PR TITLE
chore: exclude vendor directory in codeclimate

### DIFF
--- a/static/.codeclimate.yml
+++ b/static/.codeclimate.yml
@@ -14,3 +14,4 @@ ratings:
 exclude_paths:
 - db/**/*
 - node_modules/**/*
+- vendor/**/*


### PR DESCRIPTION
Pierre advices to exclude vendor directory: https://github.com/upfrontIO/livingdocs-editor/pull/662#issuecomment-188139025

@masone I'm not 100% sure with the syntax.

I want to exclude this:

```
vendor
└── jquery-ui
    └── ui
        └── jquery.ui.widget.js
```

If you give me a go, I'll merge this PR and the others PR generated by livingdocs-automation in all our repos.
