### PR TITLE
Use npm v3.8.3 or higher

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function packageUpdate (content) {
 
   pkg.engines = {
     node: '4',
-    npm: '^3.5'
+    npm: '^3.8.3'
   }
 
   return JSON.stringify(pkg, null, 2) + '\n'


### PR DESCRIPTION
We've only used that in the server & editor project. With this commit we'll distribute it everywhere.
This is the recommended npm version. http://blog.npmjs.org/post/142036323955/fixing-a-bearer-token-vulnerability
