### PR TITLE
feat(eslint): stop distribution of eslint

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ if (!token) throw new Error('Please provide a GH_TOKEN with write access in the 
 const repos = require('./repos.json')
 
 const files = {
-  '.eslintrc.json': overwrite,
   '.editorconfig': overwrite,
   'package.json': packageUpdate
 }


### PR DESCRIPTION
Since we need custom eslint configurations in our various projects, we stop the distribution of the  `.eslintrc.json` for now.